### PR TITLE
Better display selection for queue creation, needs more work, custom set...

### DIFF
--- a/simple_queue.admin.inc
+++ b/simple_queue.admin.inc
@@ -213,10 +213,10 @@ function simple_queue_edit_queue_form($form, &$form_state, $queue) {
   );
   
   $form['display'] = array(
-    '#title' => t('Default display'),
+    '#title' => t('Default View Mode'),
     '#type' => 'select',
-    '#description' => t('Select the view mode.'),
-    '#options' => simple_queue_get_view_modes_formatted(),
+    '#description' => t('The default view mode for all nodes. Until you select the allowed content types for the queue you will only have default since is the only one shared by all content types.'),
+    '#options' => simple_queue_get_view_modes_formatted($queue),
     '#default_value' => $queue->default_display,
   );
   
@@ -501,19 +501,28 @@ function simple_queue_get_all_qids($page_size = 0, $pager_element = 0, $bypass_c
 /**
  * Get view modes formatted.
  *
+ * @param $queue stdClass
+ *   The queue object
+ *
  * @return array
  *   View modes formatted.
  *
  * @author
  *   Daniel Anzawa daniel@42mate.com.
  */
-function simple_queue_get_view_modes_formatted() {
+function simple_queue_get_view_modes_formatted($queue) {
   $view_mode_formatted = array("" => 'Default');
 
-  foreach (entity_get_info('node')['view modes'] as $key => $value) {
-    if ($value['custom settings']) {
-      $view_mode_formatted[$key] = $value['label'];
-    }    
+  $entity_info = entity_get_info('node');
+  $view_modes = $entity_info['view modes'];
+
+  foreach ($queue->types as $bundle) {
+    $view_mode_settings = field_view_mode_settings('node', $bundle);
+    foreach ($view_modes as $view_mode_name => $view_mode_info) {
+      if (!empty($view_mode_settings[$view_mode_name]['custom_settings'])) {
+        $view_mode_formatted[$view_mode_name] = $view_mode_info['label'];
+      }
+    }
   }
 
   return $view_mode_formatted;


### PR DESCRIPTION
I took a look into the function simple_queue_get_view_modes_formatted

That method was trying to get the view modos and checks if the custom settings option is true. That option, as part of the entity_info method just implies if the view mode is available for all content types or not. So if we have a view mode enabled only for a single content type we are not going to be able to select the view mode as default because custom setting will be FALSE.

We need to provide the view modes depending on the selected content types for the queue. In order to do that we have to use field_view_mode_settings that uses the content type to get information of the view modes for that content type.

In this PR you'll see how to use it, the problem is that until the user select the content types and save it the only view mode available is default. If the user selects content type A and B, then, after save, the user will be able to select new view modes depending on A and B.

If you accept this PR we will have to create a JavaScript action to refresh the select list of view modes, after that the user selects the content type.

Also we will have to validate if is a valid option for display.

Last but not least, in the queue edit, we will have to show only view modes that are shared by all selected content types, no all the available view modes, only the one that are available in all selected content type, so is possible to used in any node, other wise a not valid view mode for a node will cause an error.

Keep in mind to follow this logic in the queue nodes management view, if the user appends a node of the type A, when the user selects the view mode it must select view mode valid for that node type.
